### PR TITLE
Added Codecov Workflow job to Pull Requests Workflow.

### DIFF
--- a/.github/workflows/workflow_pull_requests.yml
+++ b/.github/workflows/workflow_pull_requests.yml
@@ -31,3 +31,26 @@ jobs:
       - name: Test with pytest
         run: |
           pytest -v
+
+  codecov:
+    name: Codecov Workflow
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@master
+        with:
+          python-version: 3.8
+      - name: Generate coverage report
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install pytest-cov
+          pytest --cov=./ --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: unittests


### PR DESCRIPTION
Closes #38.

This ensures that the code coverage percentage is checked _before_ merging into master. The previous procedure was to check the code coverage when already _merged_ into master. This should prevent a lack of code coverage from making its way into master accidentally.