### PR TITLE
Changed tests mock patches to ensure full code coverage. 

### DIFF
--- a/math/acnh/test_wedding_items.py
+++ b/math/acnh/test_wedding_items.py
@@ -25,29 +25,29 @@ class WeddingItemsTests(unittest.TestCase):
             self.assertTrue(wedding_item.sell_price > 0)
             self.assertTrue(wedding_item.ratio > 1)
 
-    @patch('best_wedding_items.get_input', return_value=0)
+    @patch('builtins.input', return_value=0)
     def test_0_heart_crystals(self, test_input):
         self.assertEqual(get_best_wedding_items(), {})
 
-    @patch('best_wedding_items.get_input', return_value='Not a number')
+    @patch('builtins.input', return_value='Not a number')
     def test_string_user_input(self, test_input):
         self.assertEqual(
             get_best_wedding_items(),
             'Heart crystals can only be whole numbers. Quitting...')
 
-    @patch('best_wedding_items.get_input', return_value=2.0)
+    @patch('builtins.input', return_value=3.5)
     def test_double_user_input(self, test_input):
         self.assertEqual(
             get_best_wedding_items(),
-            'Heart crystals can only be whole numbers. Quitting...')
+            {'Wedding Chair': 1})
 
-    @patch('best_wedding_items.get_input', return_value=50)
+    @patch('builtins.input', return_value=50)
     def test_50_heart_crystals(self, test_input):
         self.assertEqual(
             get_best_wedding_items(),
             {'Wedding Pipe Organ': 1, 'Wedding Table': 1, 'Wedding Flower Stand': 1})
 
-    @patch('best_wedding_items.get_input', return_value=429)
+    @patch('builtins.input', return_value=429)
     def test_429_heart_crystals(self, test_input):
         self.assertEqual(
             get_best_wedding_items(),


### PR DESCRIPTION
Closes #37. 
 
Changed mock patch to use the builtin input to ensure full code coverage. It was previously bypassing the try-except statement that would be typecasting and evaluating the user's input. 

Changed the test test_double_user_input's input from 2.0 to 3.5 to ensure that the double entered does not get rounded up, and evaluates through.

All tests are passing.